### PR TITLE
Fix field iterating in `skipper::encode_skip` for `message_coder`

### DIFF
--- a/include/protopuf/message.h
+++ b/include/protopuf/message.h
@@ -403,7 +403,7 @@ namespace pp {
                 } else {
                     for(const auto &i : f) {
                         n += skipper<varint_coder<uint<4>>>::encode_skip(F::key);
-                        n += skipper<typename F::coder>::encode_skip(f.value());
+                        n += skipper<typename F::coder>::encode_skip(i);
                     }
                 }
             });

--- a/test/message.cpp
+++ b/test/message.cpp
@@ -97,6 +97,24 @@ GTEST_TEST(message_coder, encode) {
                                           0x05_b, 0x68_b, 0x65_b, 0x6c_b, 0x6c_b, 0x6f_b}));
     }
 
+    {
+        using Book = message<
+            string_field<"name", 1>
+        >;
+        using Student = message<
+            uint32_field<"id", 1>,
+            string_field<"name", 3>,
+            message_field<"books", 5, Book, repeated>
+        >;
+        using Class = message<
+            message_field<"students", 1, Student, repeated>
+        >;
+
+        std::array<std::byte, 64> buffer{};
+        Class c;
+        message_coder<Class>::encode(c, buffer);
+    }
+
 }
 
 GTEST_TEST(message_coder, decode) {


### PR DESCRIPTION
It closes #39.