### PR TITLE
Add out of bounds check for encoding/decoding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install build tools (gcc)
         run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt install g++-11 -y
           echo "CC=gcc-11" >> $GITHUB_ENV
           echo "CXX=g++-11" >> $GITHUB_ENV

--- a/include/protopuf/bool.h
+++ b/include/protopuf/bool.h
@@ -17,7 +17,7 @@
 
 #include "coder.h"
 #include "byte.h"
-#include "varint.h"
+#include "int.h"
 
 namespace pp {
 
@@ -27,12 +27,14 @@ namespace pp {
 
         bool_coder() = delete;
 
-        static constexpr bytes encode(bool i, bytes b) {
-            return integer_coder<uint<1>>::encode(i, b);
+        template <coder_mode Mode = unsafe_mode>
+        static constexpr encode_result<Mode> encode(bool i, bytes b) {
+            return integer_coder<uint<1>>::encode<Mode>(i, b);
         }
 
-        static constexpr decode_result<bool> decode(bytes b) {
-            return integer_coder<uint<1>>::decode(b);
+        template <coder_mode Mode = unsafe_mode>
+        static constexpr decode_result<bool, Mode> decode(bytes b) {
+            return integer_coder<uint<1>>::decode<Mode>(b);
         }
     };
 

--- a/include/protopuf/byte.h
+++ b/include/protopuf/byte.h
@@ -35,7 +35,7 @@ namespace pp {
     /// Returns the byte-distance between `begin(a)` and `begin(b)`.
     inline constexpr std::size_t begin_diff(bytes a, bytes b) {
         // `std::to_address` is used here for MSVC, ref to https://github.com/microsoft/STL/issues/1435
-        return std::to_address(a.begin()) - std::to_address(b.begin());
+        return static_cast<std::size_t>(std::to_address(a.begin()) - std::to_address(b.begin()));
     }
 }
 

--- a/include/protopuf/coder.h
+++ b/include/protopuf/coder.h
@@ -17,42 +17,60 @@
 
 #include <utility>
 #include "byte.h"
+#include "coder_mode.h"
 
 namespace pp {
+
+    /// @brief A type which `encoder`'s `encode` returns.
+    /// @param Mode the encoding mode
+    template<coder_mode Mode>
+    using encode_result = typename Mode::template result_type<bytes>;
 
     /// @brief A pair type which `decoder`'s `decode` returns.
     /// - Left type of pair `T`: the type of decoded object.
     /// - Right type of pair `bytes`: the `bytes` which remains not decoded after finishing `decode`.
     template<typename T>
-    using decode_result = std::pair<T, bytes>;
+    using decode_value = std::pair<T, bytes>;
+
+    /// @brief A type which `decoder`'s `decode` returns.
+    /// @param T the type of decoded object
+    /// @param Mode the decoding mode
+    template<typename T, coder_mode Mode>
+    using decode_result = typename Mode::template result_type<decode_value<T>>;
 
     /// @brief Describes a type with static member function `encode`, which serializes an object to `bytes` (no ownership).
     ///
+    /// Encoding can be performed in different modes.
     /// Type alias `value_type` describes type of the object to be encoded.
     /// Static member function `encode`:
     /// @param v the object to be encoded (source object).
     /// @param s the bytes which the object `v` is encoded into (target bytes).
-    /// @returns a bytes from `begin(s) + encoding_length(v)` to `end(s)`, where `encoding_length` is the length of
+    /// @returns the @ref encode_result which depends on the encoding mode.
+    /// The result contains a bytes from `begin(s) + encoding_length(v)` to `end(s)`, where `encoding_length` is the length of
     /// encoded object (bytes form), representing the left bytes which remains not used yet.
     template<typename T>
     concept encoder = requires(typename T::value_type v, bytes s) {
         typename T::value_type;
-        { T::encode(v, s) } -> std::same_as<bytes>;
+        { T::template encode<unsafe_mode>(v, s) } -> std::same_as<encode_result<unsafe_mode>>;
+        { T::template encode<safe_mode>(v, s) } -> std::same_as<encode_result<safe_mode>>;
     };
 
     /// @brief Describes a type with static member function `decode`, which deserializes some `bytes` to an object.
     ///
+    /// Decoding can be performed in different modes.
     /// Type alias `value_type` describes type of the object to be decoded.
     /// Static member function `decode`:
     /// @param s the bytes which the object is decoded from (source bytes).
-    /// @returns the @ref decode_result which is a pair including:
+    /// @returns the @ref decode_result which depends on the encoding mode.
+    /// The result contains a pair including:
     /// - the decoded object `v`;
     /// - the bytes from `begin(s) + decoding_length(v)` to `end(s)`, where `decoding_length` is the length of
     /// decoded object (bytes form), representing the left bytes which remains not used yet.
     template<typename T>
     concept decoder = requires(bytes s) {
         typename T::value_type;
-        { T::decode(s) } -> std::same_as<decode_result<typename T::value_type>>;
+        { T::template decode<unsafe_mode>(s) } -> std::same_as<decode_result<typename T::value_type, unsafe_mode>>;
+        { T::template decode<safe_mode>(s) } -> std::same_as<decode_result<typename T::value_type, safe_mode>>;
     };
 
     /// @brief Describes a type which is both @ref encoder and @ref decoder.

--- a/include/protopuf/coder_mode.h
+++ b/include/protopuf/coder_mode.h
@@ -1,0 +1,127 @@
+//   Copyright 2020-2024 PragmaTwice
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#ifndef PROTOPUF_CODER_MODE_H
+#define PROTOPUF_CODER_MODE_H
+
+#include <optional>
+#include "byte.h"
+
+namespace pp {
+
+    /// @brief Describes a type with static member function `make_result`, 
+    /// which make an encoding/decoding result which depends on the coding mode.
+    /// @param v some object that could potentially be contained as a result of encoding.
+    /// @returns the encoding/decoding result which depends on the coding mode.
+   	template<typename T>
+    concept coder_result_maker = requires(std::pair<int, int> v) {
+        typename T::template result_type<decltype(v)>;
+
+        { T::template make_result<typename T::template result_type<decltype(v)>>(0, 0) } -> 
+            std::same_as<typename T::template result_type<decltype(v)>>;
+    };
+
+    /// @brief Describes a type with static member function `get_value_from_result`, 
+    /// which extract value from encoding/decoding result depending on encoding/decoding mode.
+    /// @param v some object that could potentially be extracted from the encoding result.
+    /// @param r the encoding/decoding result.
+    /// @returns true if the value is extracted, otherwise false.
+   	template<typename T>
+    concept coder_result_value_getter = requires(std::pair<int, int> v, typename T::template result_type<decltype(v)> r) {
+        typename T::template result_type<decltype(v)>;
+
+        { T::template get_value_from_result<typename T::template result_type<decltype(v)>>(std::move(r), v) } -> std::same_as<bool>;
+    };
+
+    /// @brief Describes a type with static member function `check_iterator`, 
+    /// which checks if an iterator is valid depending on the encoding/decoding mode.
+    /// @param itr the iterator that checks for validity.
+    /// @param end the iterator to the element following the last element.
+    /// @returns true if the iterator is valid, otherwise false.
+   	template<typename T>
+    concept iterator_checker = requires(bytes::iterator itr, bytes::iterator end) {
+        { T::check_iterator(itr, end) } -> std::same_as<bool>;
+    };
+
+    /// @brief Describes a type with static member function `check_bytes_span`, 
+    /// which checks if the span offset is valid depending on the encoding/decoding mode.
+    /// @param b the byte span.
+    /// @param offset offset into the span of byte that checks for validity.
+    /// @returns true if the offset is valid, otherwise false.
+   	template<typename T>
+    concept bytes_span_checker = requires(bytes b, std::size_t offset) {
+        { T::check_bytes_span(b, offset) } -> std::same_as<bool>;
+    };
+
+    /// @brief Describes a type for the coder operating mode.
+    template<typename T>
+    concept coder_mode = coder_result_maker<T> && coder_result_value_getter<T> && iterator_checker<T> && bytes_span_checker<T>;
+
+    /// @brief Unsafe @ref coder_mode to perform coding without buffer overflow checking
+    struct unsafe_mode {
+        template<typename T>
+        using result_type = std::remove_reference_t<T>;
+
+        template<typename R, typename... Args>
+        static constexpr R make_result(Args&&... args) {
+            return R{std::forward<Args>(args)...};
+        }
+
+        template<typename T>
+        static constexpr bool get_value_from_result(T&& result, auto& value) {
+            value = std::forward<T>(result);
+            return true;
+        }
+
+        static constexpr bool check_iterator(bytes::iterator, bytes::iterator) {
+            return true;
+        }
+
+        static constexpr bool check_bytes_span(bytes, std::size_t) {
+           return true;
+        }
+    };
+
+    /// @brief Safe @ref coder_mode to perform coding with buffer overflow checking (the coding result is wrapped into std::optional)
+    struct safe_mode {
+        template<typename T>
+        using result_type = std::optional<std::remove_reference_t<T>>;
+
+        template<typename R, typename... Args>
+        static constexpr R make_result(Args&&... args) {
+            return R{std::in_place, std::forward<Args>(args)...};
+        }
+
+        template<typename T>
+        static constexpr bool get_value_from_result(T&& result, auto& value) {
+            if (result.has_value()) {
+                value = std::forward<decltype(*result)>(*result);
+            } else {
+                return false;
+            }
+            return true;
+        }
+
+        static constexpr bool check_iterator(bytes::iterator iter, bytes::iterator end) {
+            return iter != end;
+        }
+
+        static constexpr bool check_bytes_span(bytes b, std::size_t offset) {
+           return b.size() >= offset;
+        }
+    };
+
+}
+
+#endif //PROTOPUF_CODER_MODE_H

--- a/include/protopuf/field.h
+++ b/include/protopuf/field.h
@@ -308,7 +308,7 @@ namespace pp {
         }
     }
 
-    template <uint<4> V, char ... D> requires (('0' <= D <= '9') && ...)
+    template <uint<4> V, char ... D> requires ((('0' <= D) && (D <= '9')) && ...)
     constexpr auto field_literal_helper = V;
 
     template <uint<4> V, char D1, char ... Dn>

--- a/include/protopuf/fixed_string.h
+++ b/include/protopuf/fixed_string.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <algorithm>
+#include <string_view>
 
 namespace pp {
 

--- a/include/protopuf/int.h
+++ b/include/protopuf/int.h
@@ -17,6 +17,12 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <version>
+
+#if defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L
+#include <bit>
+#endif
+
 #include "coder.h"
 #include "byte.h"
 

--- a/include/protopuf/int.h
+++ b/include/protopuf/int.h
@@ -197,13 +197,23 @@ namespace pp {
 
         static constexpr std::size_t N = sizeof(T);
 
-        static constexpr bytes encode(T i, bytes b) {
+        template <coder_mode Mode = unsafe_mode>
+        static constexpr encode_result<Mode> encode(T i, bytes b) {
+            if (!Mode::check_bytes_span(b, N)) {
+                return {};
+            }
+            
             int_to_bytes<N>(i, b.subspan<0, N>());
-            return b.subspan<N>();
+            return encode_result<Mode>{b.subspan<N>()};
         }
 
-        static constexpr decode_result<T> decode(bytes b) {
-            return {bytes_to_int<N>(b.subspan<0, N>()), b.subspan<N>()};
+        template <coder_mode Mode = unsafe_mode>
+        static constexpr decode_result<T, Mode> decode(bytes b) {
+            if (!Mode::check_bytes_span(b, N)) {
+                return {};
+            }
+
+            return Mode::template make_result<decode_result<T, Mode>>(bytes_to_int<N>(b.subspan<0, N>()), b.subspan<N>());
         }
     };
 
@@ -214,12 +224,14 @@ namespace pp {
 
         integer_coder() = delete;
 
-        static constexpr bytes encode(T i, bytes b) {
-            return integer_coder<std::make_unsigned_t<T>>::encode(i, b);
+        template <coder_mode Mode = unsafe_mode>
+        static constexpr encode_result<Mode> encode(T i, bytes b) {
+            return integer_coder<std::make_unsigned_t<T>>::template encode<Mode>(static_cast<std::make_unsigned_t<T>>(i), b);
         }
 
-        static constexpr decode_result<T> decode(bytes b) {
-            return integer_coder<std::make_unsigned_t<T>>::decode(b);
+        template <coder_mode Mode = unsafe_mode>
+        static constexpr decode_result<T, Mode> decode(bytes b) {
+            return integer_coder<std::make_unsigned_t<T>>::template decode<Mode>(b);
         }
     };
 

--- a/include/protopuf/map.h
+++ b/include/protopuf/map.h
@@ -15,6 +15,7 @@
 #ifndef PROTOPUF_MAP_H
 #define PROTOPUF_MAP_H
 
+#include <map>
 #include "message.h"
 
 namespace pp {
@@ -56,8 +57,8 @@ namespace pp {
     template <typename T1, typename T2>
     constexpr bool is_message <map_element<T1, T2>> = true;
 
-    template <typename T1, typename T2>
-    struct message_decode_map<map_element<T1, T2>> : message_decode_map<typename map_element<T1, T2>::base_type> {};
+    template <coder_mode Mode, typename T1, typename T2>
+    struct message_decode_map<Mode, map_element<T1, T2>> : message_decode_map<Mode, typename map_element<T1, T2>::base_type> {};
 
     /// Type alias for map fields
     template<basic_fixed_string S, uint<4> N, coder key_coder, coder value_coder,

--- a/include/protopuf/message.h
+++ b/include/protopuf/message.h
@@ -91,7 +91,7 @@ namespace pp {
 
         template <typename... U>
             requires (sizeof...(T) == sizeof...(U) && !are_same<message, std::remove_reference_t<U>...> )
-        constexpr explicit message(U&& ...v) : T(std::forward<U>(v))... {};
+        constexpr explicit message(U&& ...v) : T(std::forward<U>(v))... {}
 
         constexpr message& operator=(const message& other) {
             ((static_cast<T&>(*this) = static_cast<const T&>(other)), ...);

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -18,38 +18,78 @@
 #include <protopuf/zigzag.h>
 #include <array>
 
+#include "test_fixture.h"
+
 using namespace pp;
 using namespace std;
 
-GTEST_TEST(array_coder, encode) {
+template<typename T>
+struct test_array_coder : test_fixture<T> {};
+TYPED_TEST_SUITE(test_array_coder, coder_mode_types, test_name_generator);
+
+TYPED_TEST(test_array_coder, encode) {
     vector<sint_zigzag<8>> con{sint_zigzag<8>(-1), sint_zigzag<8>(100000), sint_zigzag<8>(9), sint_zigzag<8>(4)};
     array<byte, 10> a{};
     array<byte, 10> e{0x06_b, 0x01_b, 0xC0_b, 0x9A_b, 0x0C_b, 0x12_b, 0x08_b};
-    auto n = array_coder<varint_coder<sint_zigzag<8>>>::encode(con, a);
+
+    bytes n;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        array_coder<varint_coder<sint_zigzag<8>>>::encode<typename TestFixture::mode>(con, a), n));
     EXPECT_EQ(begin_diff(n, a), 7);
     EXPECT_EQ(a, e);
 }
 
-GTEST_TEST(array_coder, decode) {
+TYPED_TEST(test_array_coder, decode) {
     vector<sint_zigzag<8>> con{sint_zigzag<8>(-1), sint_zigzag<8>(100000), sint_zigzag<8>(9), sint_zigzag<8>(4)};
     array<byte, 10> a{0x06_b, 0x01_b, 0xC0_b, 0x9A_b, 0x0C_b, 0x12_b, 0x08_b};
-    auto [v, n] = array_coder<varint_coder<sint_zigzag<8>>>::decode(a);
+    decode_value<vector<sint_zigzag<8>>> value;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        array_coder<varint_coder<sint_zigzag<8>>>::decode<typename TestFixture::mode>(a), value));
+    const auto& [v, n] = value;
     EXPECT_EQ(begin_diff(n, a), 7);
     EXPECT_EQ(con, v);
 }
 
-GTEST_TEST(string_coder, encode) {
+template<typename T>
+struct test_string_coder : test_fixture<T> {};
+TYPED_TEST_SUITE(test_string_coder, coder_mode_types, test_name_generator);
+
+TYPED_TEST(test_string_coder, encode) {
     array<byte, 10> e{3_b, 0x61_b, 0x62_b, 0x63_b};
     array<byte, 10> a{};
-    auto n = string_coder::encode("abc"s, a);
+    bytes n;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        string_coder::encode<typename TestFixture::mode>("abc"s, a), n));
     EXPECT_EQ(begin_diff(n, a), 4);
     EXPECT_EQ(a, e);
 }
 
-GTEST_TEST(string_coder, decode) {
+TYPED_TEST(test_string_coder, decode) {
     auto e = "abc"s;
     array<byte, 10> a{3_b, 0x61_b, 0x62_b, 0x63_b};
-    auto [v, n] = string_coder::decode(a);
+    decode_value<std::string> value;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        string_coder::decode<typename TestFixture::mode>(a), value));
+    const auto& [v, n] = value;
     EXPECT_EQ(begin_diff(n, a), 4);
     EXPECT_EQ(v, e);
+}
+
+GTEST_TEST(array_coder, encode_with_insufficient_buffer_size) {
+    const vector<sint_zigzag<8>> con{sint_zigzag<8>(-1), sint_zigzag<8>(100000), sint_zigzag<8>(9), sint_zigzag<8>(4)};
+    run_safe_encode_tests_with_insufficient_buffer_size<array_coder<varint_coder<sint_zigzag<8>>>, 7>(con);
+}
+
+GTEST_TEST(array_coder, decode_with_insufficient_buffer_size) {
+    array<byte, 7> a{0x06_b, 0x01_b, 0xC0_b, 0x9A_b, 0x0C_b, 0x12_b, 0x08_b};
+    run_safe_decode_tests_with_insufficient_buffer_size<array_coder<varint_coder<sint_zigzag<8>>>>(a);
+}
+
+GTEST_TEST(string_coder, encode_with_insufficient_buffer_size) {
+    run_safe_encode_tests_with_insufficient_buffer_size<string_coder, 4>("abc"s);
+}
+
+GTEST_TEST(string_coder, decode_with_insufficient_buffer_size) {
+    array<byte, 4> a{3_b, 0x61_b, 0x62_b, 0x63_b};
+    run_safe_decode_tests_with_insufficient_buffer_size<string_coder>(a);
 }

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -35,6 +35,18 @@ void BM_protopuf_encode(benchmark::State& state) {
 }
 BENCHMARK(BM_protopuf_encode);
 
+void BM_protopuf_safe_encode(benchmark::State& state) {
+    Student twice {123, "twice"}, tom{456, "tom"}, jerry{123456, "jerry"};
+    Class myClass {"class 101", {tom, jerry, twice}};
+
+    array<byte, 64> buffer{};
+
+    for(auto _ : state) {
+        message_coder<Class>::encode<safe_mode>(myClass, buffer);
+    }
+}
+BENCHMARK(BM_protopuf_safe_encode);
+
 void BM_protobuf_encode(benchmark::State& state) {
     pb::Class yourClass;
     yourClass.set_name("class 101");
@@ -74,6 +86,14 @@ void BM_protopuf_decode(benchmark::State& state) {
     }
 }
 BENCHMARK(BM_protopuf_decode);
+
+void BM_protopuf_safe_decode(benchmark::State& state) {
+    for(auto _ : state) {
+        auto [myClass, _2] = *message_coder<Class>::decode<safe_mode>(decode_buffer);
+        benchmark::DoNotOptimize(myClass);
+    }
+}
+BENCHMARK(BM_protopuf_safe_decode);
 
 void BM_protobuf_decode(benchmark::State& state) {
     for(auto _ : state) {

--- a/test/bool.cpp
+++ b/test/bool.cpp
@@ -17,24 +17,38 @@
 #include <protopuf/bool.h>
 #include <array>
 
+#include "test_fixture.h"
+
 using namespace pp;
 using namespace std;
 
-GTEST_TEST(bool_coder, encode) {
+template<typename T>
+struct test_bool_coder : test_fixture<T> {};
+TYPED_TEST_SUITE(test_bool_coder, coder_mode_types, test_name_generator);
+
+TYPED_TEST(test_bool_coder, encode) {
     array<byte, 10> a{};
 
-    EXPECT_EQ(begin_diff(bool_coder::encode(true, a), a), 1);
+    bytes n;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        bool_coder::encode<typename TestFixture::mode>(true, a), n));
+    EXPECT_EQ(begin_diff(n, a), 1);
     EXPECT_EQ(a[0], 1_b);
 
-    EXPECT_EQ(begin_diff(bool_coder::encode(false, a), a), 1);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        bool_coder::encode<typename TestFixture::mode>(false, a), n));
+    EXPECT_EQ(begin_diff(n, a), 1);
     EXPECT_EQ(a[0], 0_b);
 }
 
-GTEST_TEST(bool_coder, decode) {
+TYPED_TEST(test_bool_coder, decode) {
     array<byte, 10> a{};
 
     {
-        auto[v, n] = bool_coder::decode(a);
+        decode_value<bool> value;
+        ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+            bool_coder::decode<typename TestFixture::mode>(a), value));
+        auto[v, n] = value;
         EXPECT_EQ(begin_diff(n, a), 1);
         EXPECT_EQ(v, false);
     }
@@ -42,7 +56,10 @@ GTEST_TEST(bool_coder, decode) {
     {
         a[0] = 1_b;
 
-        auto[v, n] = bool_coder::decode(a);
+        decode_value<bool> value;
+        ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+            bool_coder::decode<typename TestFixture::mode>(a), value));
+        auto[v, n] = value;
         EXPECT_EQ(begin_diff(n, a), 1);
         EXPECT_EQ(v, true);
     }

--- a/test/compatibility/test_fixture.h
+++ b/test/compatibility/test_fixture.h
@@ -1,0 +1,37 @@
+//   Copyright 2020-2024 PragmaTwice
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#ifndef PROTOPUF_TEST_FIXTURE_H
+#define PROTOPUF_TEST_FIXTURE_H
+
+#include <gtest/gtest.h>
+#include <protopuf/coder_mode.h>
+
+template<typename T>
+struct test_fixture : testing::Test {
+    using mode = T;
+};
+
+using coder_mode_types = testing::Types<pp::unsafe_mode, pp::safe_mode>;
+
+class test_name_generator {
+public:
+  template<typename T>
+  static std::string GetName(int) {
+    if constexpr (std::is_same_v<T, pp::safe_mode>) return "safe";
+    if constexpr (std::is_same_v<T, pp::unsafe_mode>) return "unsafe";
+  }
+};
+
+#endif //PROTOPUF_TEST_FIXTURE_H

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -18,47 +18,68 @@
 #include <protopuf/enum.h>
 #include <array>
 
+#include "test_fixture.h"
+
 using namespace pp;
 using namespace std;
 
-GTEST_TEST(enum_coder, encode) {
+template<typename T>
+struct test_enum_coder : test_fixture<T> {};
+TYPED_TEST_SUITE(test_enum_coder, coder_mode_types, test_name_generator);
+
+TYPED_TEST(test_enum_coder, encode) {
     array<byte, 10> a{};
+    bytes b;
 
     enum E1 { red, green, blue = 128 };
 
-    EXPECT_EQ(begin_diff(enum_coder<E1>::encode(green, a), a), 1);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        enum_coder<E1>::template encode<typename TestFixture::mode>(green, a), b));
+    EXPECT_EQ(begin_diff(b, a), 1);
     EXPECT_EQ(a[0], 1_b);
 
-    EXPECT_EQ(begin_diff(enum_coder<E1>::encode(blue, a), a), 2);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        enum_coder<E1>::template encode<typename TestFixture::mode>(blue, a), b));
+    EXPECT_EQ(begin_diff(b, a), 2);
     EXPECT_EQ(a[0], 0x80_b);
     EXPECT_EQ(a[1], 0x1_b);
 
     enum class E2 { red, green, blue };
 
-    EXPECT_EQ(begin_diff(enum_coder<E2>::encode(E2::green, a), a), 1);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        enum_coder<E2>::template encode<typename TestFixture::mode>(E2::green, a), b));
+    EXPECT_EQ(begin_diff(b, a), 1);
     EXPECT_EQ(a[0], 1_b);
 
     enum E3 : pp::uint<8> { x, y, z };
 
-    EXPECT_EQ(begin_diff(enum_coder<E3>::encode(z, a), a), 1);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        enum_coder<E3>::template encode<typename TestFixture::mode>(z, a), b));
+    EXPECT_EQ(begin_diff(b, a), 1);
     EXPECT_EQ(a[0], 2_b);
 }
 
-GTEST_TEST(enum_coder, decode) {
+TYPED_TEST(test_enum_coder, decode) {
     array<byte, 10> a{};
 
     enum E1 { red, green, blue = 128 };
 
     {
         a[0] = 1_b;
-        auto [v, n] = enum_coder<E1>::decode(a);
+        decode_value<E1> value;
+        ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+            enum_coder<E1>::template decode<typename TestFixture::mode>(a), value));
+        auto [v, n] = value;
         EXPECT_EQ(begin_diff(n, a), 1);
         EXPECT_EQ(v, green);
     }
 
     {
         a[0] = 0x80_b; a[1] = 0x1_b;
-        auto [v, n] = enum_coder<E1>::decode(a);
+        decode_value<E1> value;
+        ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+            enum_coder<E1>::template decode<typename TestFixture::mode>(a), value));
+        auto [v, n] = value;
         EXPECT_EQ(begin_diff(n, a), 2);
         EXPECT_EQ(v, blue);
     }
@@ -67,7 +88,10 @@ GTEST_TEST(enum_coder, decode) {
 
     {
         a[0] = 0x1_b;
-        auto [v, n] = enum_coder<E2>::decode(a);
+        decode_value<E2> value;
+        ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+            enum_coder<E2>::template decode<typename TestFixture::mode>(a), value));
+        auto [v, n] = value;
         EXPECT_EQ(begin_diff(n, a), 1);
         EXPECT_EQ(v, E2::green);
     }
@@ -76,8 +100,22 @@ GTEST_TEST(enum_coder, decode) {
 
     {
         a[0] = 0x2_b;
-        auto [v, n] = enum_coder<E3>::decode(a);
+        decode_value<E3> value;
+        ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+            enum_coder<E3>::template decode<typename TestFixture::mode>(a), value));
+        auto [v, n] = value;
         EXPECT_EQ(begin_diff(n, a), 1);
         EXPECT_EQ(v, z);
     }
+}
+
+GTEST_TEST(enum_coder, encode_with_insufficient_buffer_size) {
+    enum E1 { red, green, blue = 128 };
+    run_safe_encode_tests_with_insufficient_buffer_size<enum_coder<E1>, 2>(blue);
+}
+
+GTEST_TEST(enum_coder, decode_with_insufficient_buffer_size) {
+    enum E1 { red, green, blue = 128 };
+    array<byte, 2> a{0x80_b, 0x1_b};
+    run_safe_decode_tests_with_insufficient_buffer_size<enum_coder<E1>>(a);
 }

--- a/test/float.cpp
+++ b/test/float.cpp
@@ -17,51 +17,85 @@
 #include <protopuf/float.h>
 #include <array>
 
+#include "test_fixture.h"
+
 using namespace pp;
 using namespace std;
 
-GTEST_TEST(float_coder, encode) {
+template<typename T>
+struct test_float_coder : test_fixture<T> {};
+TYPED_TEST_SUITE(test_float_coder, coder_mode_types, test_name_generator);
+
+TYPED_TEST(test_float_coder, encode) {
     array<byte, 4> a{};
-    auto n = float_coder<float>::encode(0, a);
+    bytes n;
+
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::encode<typename TestFixture::mode>(0, a), n));
     EXPECT_EQ(begin_diff(n, a), 4);
     EXPECT_EQ(a, (array{0_b, 0_b, 0_b, 0_b}));
 
-    n = float_coder<float>::encode(1, a);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::encode<typename TestFixture::mode>(1, a), n));
     EXPECT_EQ(begin_diff(n, a), 4);
     EXPECT_EQ(a, (array{0_b, 0_b, 0x80_b, 0x3f_b}));
 
-    n = float_coder<float>::encode(-1, a);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::encode<typename TestFixture::mode>(-1, a), n));
     EXPECT_EQ(begin_diff(n, a), 4);
     EXPECT_EQ(a, (array{0_b, 0_b, 0x80_b, 0xbf_b}));
 
-    n = float_coder<float>::encode(1.234, a);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::encode<typename TestFixture::mode>(1.234f, a), n));
     EXPECT_EQ(begin_diff(n, a), 4);
     EXPECT_EQ(a, (array{0xb6_b, 0xf3_b, 0x9d_b, 0x3f_b}));
 
-    n = float_coder<float>::encode(1.234e5, a);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::encode<typename TestFixture::mode>(1.234e5, a), n));
     EXPECT_EQ(begin_diff(n, a), 4);
     EXPECT_EQ(a, (array{0_b, 0x04_b, 0xf1_b, 0x47_b}));
 }
 
-GTEST_TEST(float_coder, decoder) {
+TYPED_TEST(test_float_coder, decoder) {
+    decode_value<float> value;
+
     array a{0_b, 0_b, 0_b, 0_b};
-    auto [v, n] = float_coder<float>::decode(a);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::decode<typename TestFixture::mode>(a), value));
+    auto [v, n] = value;
     EXPECT_EQ(v, 0.);
     EXPECT_EQ(begin_diff(n, a), 4);
 
     a = {0_b, 0_b, 0x80_b, 0x3f_b};
-    tie(v, n) = float_coder<float>::decode(a);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::decode<typename TestFixture::mode>(a), value));
+    tie(v, n) = value;
     EXPECT_FLOAT_EQ(v, 1);
 
     a = {0_b, 0_b, 0x80_b, 0xbf_b};
-    tie(v, n) = float_coder<float>::decode(a);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::decode<typename TestFixture::mode>(a), value));
+    tie(v, n) = value;
     EXPECT_FLOAT_EQ(v, -1);
 
     a = {0xb6_b, 0xf3_b, 0x9d_b, 0x3f_b};
-    tie(v, n) = float_coder<float>::decode(a);
-    EXPECT_FLOAT_EQ(v, 1.234);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::decode<typename TestFixture::mode>(a), value));
+    tie(v, n) = value;
+    EXPECT_FLOAT_EQ(v, 1.234f);
 
     a = {0_b, 0x04_b, 0xf1_b, 0x47_b};
-    tie(v, n) = float_coder<float>::decode(a);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        float_coder<float>::decode<typename TestFixture::mode>(a), value));
+    tie(v, n) = value;
     EXPECT_FLOAT_EQ(v, 1.234e5);
+}
+
+GTEST_TEST(float_coder, encode_with_insufficient_buffer_size) {
+    run_safe_encode_tests_with_insufficient_buffer_size<float_coder<float>, 4>(1.234f);
+}
+
+GTEST_TEST(float_coder, decode_with_insufficient_buffer_size) {
+    array<byte, 4> a{0xb6_b, 0xf3_b, 0x9d_b, 0x3f_b};
+    run_safe_decode_tests_with_insufficient_buffer_size<float_coder<float>>(a);
 }

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -17,30 +17,45 @@
 #include <protopuf/map.h>
 #include <array>
 
+#include "test_fixture.h"
+
 using namespace pp;
 using namespace std;
 
+template<typename T>
+struct test_map : test_fixture<T> {};
+TYPED_TEST_SUITE(test_map, coder_mode_types, test_name_generator);
+
 using StrIntMap = message<map_field<"map", 233, string_coder, varint_coder<int>>>;
 
-GTEST_TEST(map, encode) {
+TYPED_TEST(test_map, encode) {
     StrIntMap map{ {{"b", 2}, {"a", 1}, {"c", 3}} };
     array<byte, 30> buffer{};
+    bytes b;
 
-    message_coder<StrIntMap>::encode(map, buffer);
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        message_coder<StrIntMap>::encode<typename TestFixture::mode>(map, buffer), b));
+
     array<byte, 30> buffer_exp { 0xca_b, 0x0e_b, 0x05_b, 0x0a_b, 0x01_b, 0x61_b, 0x10_b, 0x01_b, 0xca_b, 0x0e_b, 0x05_b, 0x0a_b, 0x01_b, 0x62_b, 0x10_b, 0x02_b, 0xca_b, 0x0e_b, 0x05_b, 0x0a_b, 0x01_b, 0x63_b, 0x10_b, 0x03_b };
     EXPECT_EQ(buffer, buffer_exp);
 }
 
-GTEST_TEST(map, decode) {
+TYPED_TEST(test_map, decode) {
     array<byte, 30> buffer { 0xca_b, 0x0e_b, 0x05_b, 0x0a_b, 0x01_b, 0x61_b, 0x10_b, 0x01_b, 0xca_b, 0x0e_b, 0x05_b, 0x0a_b, 0x01_b, 0x62_b, 0x10_b, 0x02_b, 0xca_b, 0x0e_b, 0x05_b, 0x0a_b, 0x01_b, 0x63_b, 0x10_b, 0x03_b };
     
-    auto [map, _] = message_coder<StrIntMap>::decode(buffer);
+    decode_value<StrIntMap> value;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+       message_coder<StrIntMap>::decode<typename TestFixture::mode>(buffer), value));
+    auto [map, _] = value;
+    ASSERT_EQ(map["map"_f].count("a"), 1);
+    ASSERT_EQ(map["map"_f].count("b"), 1);
+    ASSERT_EQ(map["map"_f].count("c"), 1);
     EXPECT_EQ(map["map"_f].at("a"), 1);
     EXPECT_EQ(map["map"_f].at("b"), 2);
     EXPECT_EQ(map["map"_f].at("c"), 3);
 }
 
-GTEST_TEST(map, utility) {
+GTEST_TEST(test_map, utility) {
     using Msg = message<map_field<"data", 11, string_coder, varint_coder<int>>>;
 
     Msg msg1 {{{"one", 1}, {"two", 2}, {"three", 3}}}, msg2 {{{"four", 4}, {"five", 5}}};
@@ -49,4 +64,18 @@ GTEST_TEST(map, utility) {
 
     EXPECT_EQ(msg1["data"_f].size(), 5);
     EXPECT_EQ(msg1["data"_f], (map<optional<string>, optional<int>>{{"one", 1}, {"two", 2}, {"three", 3}, {"four", 4}, {"five", 5}}));
+}
+
+GTEST_TEST(map_coder, encode_with_insufficient_buffer_size) {
+    const StrIntMap map{ {{"b", 2}, {"a", 1}, {"c", 3}} };
+    run_safe_encode_tests_with_insufficient_buffer_size<message_coder<StrIntMap>, 24>(map);
+}
+
+GTEST_TEST(map_coder, decode_with_insufficient_buffer_size) {
+    array<byte, 24> a { 0xca_b, 0x0e_b, 0x05_b, 0x0a_b, 0x01_b, 0x61_b, 0x10_b, 0x01_b, 0xca_b, 0x0e_b, 0x05_b, 0x0a_b, 0x01_b, 0x62_b, 0x10_b, 0x02_b, 0xca_b, 0x0e_b, 0x05_b, 0x0a_b, 0x01_b, 0x63_b, 0x10_b, 0x03_b };
+    run_safe_decode_test_with_insufficient_buffer_size<message_coder<StrIntMap>, 5>(a);
+    run_safe_decode_test_with_insufficient_buffer_size<message_coder<StrIntMap>, 15>(a);
+    run_safe_decode_test_with_insufficient_buffer_size<message_coder<StrIntMap>, 17>(a);
+    run_safe_decode_test_with_insufficient_buffer_size<message_coder<StrIntMap>, 20>(a);
+    run_safe_decode_test_with_insufficient_buffer_size<message_coder<StrIntMap>, 21>(a);
 }

--- a/test/test_fixture.h
+++ b/test/test_fixture.h
@@ -1,0 +1,77 @@
+//   Copyright 2020-2024 PragmaTwice
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#ifndef PROTOPUF_TEST_FIXTURE_H
+#define PROTOPUF_TEST_FIXTURE_H
+
+#include <version>
+
+#if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
+#include <source_location>
+using source_location = std::source_location;
+#else
+#include <experimental/source_location>
+using source_location = std::experimental::source_location;
+#endif
+
+#include <gtest/gtest.h>
+#include <protopuf/coder.h>
+
+template<typename T>
+struct test_fixture : testing::Test {
+    using mode = T;
+};
+
+using coder_mode_types = testing::Types<pp::unsafe_mode, pp::safe_mode>;
+
+class test_name_generator {
+public:
+    template<typename T>
+    static std::string GetName(int) {
+        if constexpr (std::is_same_v<T, pp::safe_mode>) return "safe";
+        if constexpr (std::is_same_v<T, pp::unsafe_mode>) return "unsafe";
+  }
+};
+
+template<pp::coder Coder, std::size_t size>
+inline void run_safe_encode_test_with_insufficient_buffer_size(const auto& container, const source_location& location) {
+    std::array<std::byte, size> a{};
+    ASSERT_FALSE(Coder::template encode<pp::safe_mode>(container, a)) << "Buffer size " << size << ' ' <<
+        '(' << location.file_name() << ':' << location.line() << ')';
+}
+
+template<pp::coder Coder, std::size_t size>
+inline void run_safe_encode_tests_with_insufficient_buffer_size(const auto& container, const source_location location =
+               source_location::current()) {
+    [] <std::size_t... sizes> (const auto& container, std::index_sequence<sizes...>, const source_location& location) {
+        (run_safe_encode_test_with_insufficient_buffer_size<Coder, sizes>(container, location), ...);
+    } (container, std::make_index_sequence<size>{}, location);
+}
+
+template<pp::coder Coder, std::size_t size>
+inline void run_safe_decode_test_with_insufficient_buffer_size(pp::bytes buffer, const source_location& location =
+                source_location::current()) {
+    ASSERT_FALSE(Coder::template decode<pp::safe_mode>(buffer.subspan(0, size))) << "Buffer size " << size << ' ' <<
+        '(' << location.file_name() << ':' << location.line() << ')';
+}
+
+template<pp::coder Coder, std::size_t size>
+inline void run_safe_decode_tests_with_insufficient_buffer_size(std::array<std::byte, size>& buffer, const source_location& location =
+               source_location::current()) {
+    [] <std::size_t... sizes> (pp::bytes buffer, std::index_sequence<sizes...>, const source_location& location) {
+        (run_safe_decode_test_with_insufficient_buffer_size<Coder, sizes>(buffer, location), ...);
+    } (buffer, std::make_index_sequence<size>{}, location);
+}
+
+#endif //PROTOPUF_TEST_FIXTURE_H

--- a/test/zigzag.cpp
+++ b/test/zigzag.cpp
@@ -18,6 +18,8 @@
 
 #include <array>
 
+#include "test_fixture.h"
+
 using namespace pp;
 using namespace std;
 
@@ -64,26 +66,60 @@ GTEST_TEST(sint_zigzag, bytes) {
     EXPECT_EQ(p10k.dump(), a10k);
 }
 
-GTEST_TEST(sint_zigzag, integer_coder) {
+template<typename T>
+struct test_sint_zigzag : test_fixture<T> {};
+TYPED_TEST_SUITE(test_sint_zigzag, coder_mode_types, test_name_generator);
+
+TYPED_TEST(test_sint_zigzag, integer_coder) {
     sint_zigzag<4> p10k(10000);
     array a10k {0x20_b, 0x4e_b, 0_b, 0_b};
 
     array<byte, 4> a10ke {};
-    integer_coder<sint_zigzag<4>>::encode(p10k, span(a10ke));
+    bytes b;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        integer_coder<sint_zigzag<4>>::encode<typename TestFixture::mode>(p10k, a10ke), b));
     EXPECT_EQ(a10k, a10ke);
 
-    auto [p10ke, _] = integer_coder<sint_zigzag<4>>::decode(span(a10k));
+    decode_value<sint_zigzag<4>> value;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        integer_coder<sint_zigzag<4>>::decode<typename TestFixture::mode>(a10k), value));
+    auto [p10ke, _] = value;
     EXPECT_EQ(p10k, p10ke);
 }
 
-GTEST_TEST(sint_zigzag, varint_coder) {
+TYPED_TEST(test_sint_zigzag, varint_coder) {
     sint_zigzag<4> p10k(10000);
     array a10k {0xa0_b, 0x9c_b, 0x01_b, 0_b};
 
     array<byte, 4> a10ke {};
-    varint_coder<sint_zigzag<4>>::encode(p10k, span(a10ke));
+    bytes b;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        varint_coder<sint_zigzag<4>>::encode<typename TestFixture::mode>(p10k, a10ke), b));
     EXPECT_EQ(a10k, a10ke);
 
-    auto [p10ke, _] = varint_coder<sint_zigzag<4>>::decode(span(a10k));
+    decode_value<sint_zigzag<4>> value;
+    ASSERT_TRUE(TestFixture::mode::get_value_from_result(
+        varint_coder<sint_zigzag<4>>::decode<typename TestFixture::mode>(a10k), value));
+    auto [p10ke, _] = value;
     EXPECT_EQ(p10k, p10ke);
+}
+
+GTEST_TEST(sint_zigzag_integer_coder, encode_with_insufficient_buffer_size) {
+    const sint_zigzag<4> p10k(10000);
+    run_safe_encode_tests_with_insufficient_buffer_size<integer_coder<sint_zigzag<4>>, 4>(p10k);
+}
+
+GTEST_TEST(sint_zigzag_integer_coder, decode_with_insufficient_buffer_size) {
+    array a10k {0x20_b, 0x4e_b, 0_b, 0_b};
+    run_safe_decode_tests_with_insufficient_buffer_size<integer_coder<sint_zigzag<4>>>(a10k);
+}
+
+GTEST_TEST(sint_zigzag_varint_coder, encode_with_insufficient_buffer_size) {
+    const sint_zigzag<4> p10k(10000);
+    run_safe_encode_tests_with_insufficient_buffer_size<varint_coder<sint_zigzag<4>>, 3>(p10k);
+}
+
+GTEST_TEST(sint_zigzag_varint_coder, decode_with_insufficient_buffer_size) {
+    array a10k {0xa0_b, 0x9c_b, 0x01_b};
+    run_safe_decode_tests_with_insufficient_buffer_size<varint_coder<sint_zigzag<4>>>(a10k);
 }


### PR DESCRIPTION
Added the ability to select the encoding/decoding mode. If the safe mode is selected, then the buffer is checked for going beyond the boundaries. In this mode, the result is wrapped in std::optional.
In the unsafe mode (which is selected by default), no checks are performed. The encoding result is similar to what it was before the changes. 
The decoding result is almost compatible with what it was before the changes (when assigning the result to a variable with the type 'auto', nothing in the old code will need to be changed).

Also the code is prepared for compilation with the flags -Wall -Werror -Wextra -Wconversion -pedantic.