### PR TITLE
feat: add merge_mode for field merging

### DIFF
--- a/include/protopuf/message.h
+++ b/include/protopuf/message.h
@@ -226,9 +226,9 @@ namespace pp {
         /// @brief Merge another message into this message, for all fields: overwrite if it is singular and non-empty, merge to end otherwise
         ///
         /// same as `merge_field(field1, other.field1), ..., merge_field(fieldN, other.fieldN)`, ref to @ref merge_field
-        template <typename M> requires std::same_as<std::remove_cvref_t<M>, message>
+        template <merge_mode mode = merge_mode{}, typename M> requires std::same_as<std::remove_cvref_t<M>, message>
         constexpr void merge(M&& other) {
-            (merge_field(static_cast<T&>(*this), static_cast<type_forward<T, M&&>>(other)), ...);
+            (merge_field<mode>(static_cast<T&>(*this), static_cast<type_forward<T, M&&>>(other)), ...);
         }
     };
 
@@ -244,13 +244,13 @@ namespace pp {
     concept message_c = is_message<T>;
 
     /// Merge multiple messages into one message, and return the merged message
-    template <typename M1, typename... MN> 
+    template <merge_mode mode = merge_mode{}, typename M1, typename... MN>
     requires message_c<std::remove_cvref_t<M1>> && 
              are_same<std::remove_cvref_t<M1>, std::remove_cvref_t<MN>...>
     constexpr auto merge(M1&& msg1, MN&& ... msgN) {
         std::remove_cvref_t<M1> res = std::forward<M1>(msg1);
 
-        (res.merge(std::forward<MN>(msgN)), ...);
+        (res.template merge<mode>(std::forward<MN>(msgN)), ...);
 
         return res;
     }

--- a/test/message.cpp
+++ b/test/message.cpp
@@ -474,6 +474,13 @@ GTEST_TEST(message, merge) {
     EXPECT_EQ(merged["name"_f], "e");
     EXPECT_EQ(merged["titles"_f], (vector<string>{"b", "c", "d", "f"}));
     EXPECT_EQ(merged["age"_f], 124);
+
+    constexpr merge_mode mode{merge_mode::singular::assign_if_empty};
+    merged = merge<mode>(merged, Person{"a", {}, {}});
+    EXPECT_EQ(merged["name"_f], "e");
+
+    merged = merge<mode>(Person{{}, {}, {}}, Person{"a", {}, {}});
+    EXPECT_EQ(merged["name"_f], "a");
 }
 
 GTEST_TEST(message_coder, encode_with_insufficient_buffer_size) {


### PR DESCRIPTION
We add `merge_mode` as a template parameter of `merge_field`, `message::merge` and `merge`, in a API-compatible manner.