### PR TITLE
ci: fix doxygen build in doc CI

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -15,13 +15,11 @@ jobs:
           submodules: true
       - name: install deps
         run: |
-          sudo apt update
-          sudo apt install -y libclang-12-dev
           git clone https://github.com/doxygen/doxygen doxygen-tool
           cd doxygen-tool
           mkdir build
           cd build
-          cmake -Duse_libclang=ON -DCMAKE_PREFIX_PATH=/usr/lib/llvm-12/ ..
+          cmake -Duse_libclang=ON ..
           make -j$(nproc)
           sudo make install
           cd ../..

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -15,11 +15,13 @@ jobs:
           submodules: true
       - name: install deps
         run: |
+          sudo apt update
+          sudo apt install -y libclang-15-dev
           git clone https://github.com/doxygen/doxygen doxygen-tool
           cd doxygen-tool
           mkdir build
           cd build
-          cmake -Duse_libclang=ON ..
+          cmake -Duse_libclang=ON -DCMAKE_PREFIX_PATH=/usr/lib/llvm-15/ ..
           make -j$(nproc)
           sudo make install
           cd ../..


### PR DESCRIPTION
In ubuntu-22.04 we should use libclang-15 instead of libclang-12.