### PR TITLE
fix(array): add missing header to make MSVC happy

### DIFF
--- a/include/protopuf/array.h
+++ b/include/protopuf/array.h
@@ -16,6 +16,7 @@
 #define PROTOPUF_ARRAY_H
 
 #include <ranges>
+#include <string>
 #include <vector>
 #include "coder.h"
 #include "varint.h"


### PR DESCRIPTION
include\protopuf\array.h(134): error C2039: 'basic_string': is not a member of 'std'
