### PR TITLE
Improve decode performance

### DIFF
--- a/include/protopuf/array.h
+++ b/include/protopuf/array.h
@@ -81,11 +81,11 @@ namespace pp {
                 con.reserve(len);
             }
 
-            const auto origin_b = b;
             decode_value<typename C::value_type> decode_v;
-            while(begin_diff(b, origin_b) < len) {
+            while(len) {
                 if (Mode::get_value_from_result(C::template decode<Mode>(b), decode_v)) {
                     std::tie(*std::inserter(con, con.end()), b) = std::move(decode_v);
+                    --len;
                 } else {
                     return {};
                 }
@@ -122,8 +122,10 @@ namespace pp {
             uint<8> n = 0;
             std::tie(n, b) = decode_len;
 
-            if (!Mode::check_bytes_span(b, n)) {
-                return {};
+            if constexpr (Mode::need_checks) {
+                if (!Mode::check_bytes_span(b, n)) {
+                    return {};
+                }
             }
 
             return Mode::template make_result<decode_skip_result<Mode>>(b.subspan(n));

--- a/include/protopuf/byte.h
+++ b/include/protopuf/byte.h
@@ -32,11 +32,6 @@ namespace pp {
     /// A byte (contiguous) sequence reference (no ownership).
     using bytes = std::span<std::byte>;
 
-    /// Returns the byte-distance between `begin(a)` and `begin(b)`.
-    inline constexpr std::size_t begin_diff(bytes a, bytes b) {
-        // `std::to_address` is used here for MSVC, ref to https://github.com/microsoft/STL/issues/1435
-        return static_cast<std::size_t>(std::to_address(a.begin()) - std::to_address(b.begin()));
-    }
 }
 
 #endif //PROTOPUF_BYTE_H

--- a/include/protopuf/coder_mode.h
+++ b/include/protopuf/coder_mode.h
@@ -73,6 +73,8 @@ namespace pp {
         template<typename T>
         using result_type = std::remove_reference_t<T>;
 
+        static constexpr bool need_checks = false;
+
         template<typename R, typename... Args>
         static constexpr R make_result(Args&&... args) {
             return R{std::forward<Args>(args)...};
@@ -97,6 +99,8 @@ namespace pp {
     struct safe_mode {
         template<typename T>
         using result_type = std::optional<std::remove_reference_t<T>>;
+
+        static constexpr bool need_checks = true;
 
         template<typename R, typename... Args>
         static constexpr R make_result(Args&&... args) {

--- a/include/protopuf/int.h
+++ b/include/protopuf/int.h
@@ -199,8 +199,10 @@ namespace pp {
 
         template <coder_mode Mode = safe_mode>
         static constexpr encode_result<Mode> encode(T i, bytes b) {
-            if (!Mode::check_bytes_span(b, N)) {
-                return {};
+            if constexpr (Mode::need_checks) {
+                if (!Mode::check_bytes_span(b, N)) {
+                    return {};
+                }
             }
             
             int_to_bytes<N>(i, b.subspan<0, N>());
@@ -209,8 +211,10 @@ namespace pp {
 
         template <coder_mode Mode = safe_mode>
         static constexpr decode_result<T, Mode> decode(bytes b) {
-            if (!Mode::check_bytes_span(b, N)) {
-                return {};
+            if constexpr (Mode::need_checks) {
+                if (!Mode::check_bytes_span(b, N)) {
+                    return {};
+                }
             }
 
             return Mode::template make_result<decode_result<T, Mode>>(bytes_to_int<N>(b.subspan<0, N>()), b.subspan<N>());

--- a/include/protopuf/message.h
+++ b/include/protopuf/message.h
@@ -489,13 +489,13 @@ namespace pp {
             std::size_t len = 0;
             std::tie(len, b) = decod_len;
 
-            const auto origin_b = b;
-            while(begin_diff(b, origin_b) < len) {
+            while(len) {
                 std::pair<bytes, bool> bytes_with_next;
                 if (!Mode::get_value_from_result(decode_map<Mode, T>.decode(v, b), bytes_with_next)) {
                     return {};
                 }
 
+                --len;
                 bool next = true;
                 std::tie(b, next) = bytes_with_next;
 
@@ -528,8 +528,10 @@ namespace pp {
             uint<8> n = 0;
             std::tie(n, b) = decode_len;
 
-            if (!Mode::check_bytes_span(b, n)) {
-                return {};
+            if constexpr (Mode::need_checks) {
+                if (!Mode::check_bytes_span(b, n)) {
+                    return {};
+                }
             }
 
             return Mode::template make_result<decode_skip_result<Mode>>(b.subspan(n));

--- a/include/protopuf/skip.h
+++ b/include/protopuf/skip.h
@@ -82,8 +82,10 @@ namespace pp {
 
         template <coder_mode Mode = safe_mode>
         static constexpr decode_skip_result<Mode> decode_skip(bytes b) {
-            if (!Mode::check_bytes_span(b, sizeof(T))) {
-                return {};
+            if constexpr (Mode::need_checks) {
+                if (!Mode::check_bytes_span(b, sizeof(T))) {
+                    return {};
+                }
             }
             return Mode::template make_result<decode_skip_result<Mode>>(b.subspan<sizeof(T)>());
         }
@@ -100,8 +102,10 @@ namespace pp {
 
         template <coder_mode Mode = safe_mode>
         static constexpr decode_skip_result<Mode> decode_skip(bytes b) {
-            if (!Mode::check_bytes_span(b, sizeof(T))) {
-                return {};
+            if constexpr (Mode::need_checks) {
+                if (!Mode::check_bytes_span(b, sizeof(T))) {
+                    return {};
+                }
             }
             return Mode::template make_result<decode_skip_result<Mode>>(b.subspan<sizeof(T)>());
         }
@@ -127,13 +131,17 @@ namespace pp {
             auto iter = b.begin();
             const auto end = b.end();
 
-            if (!Mode::check_iterator(iter, end)) {
-                return {};
+            if constexpr (Mode::need_checks) {
+                if (!Mode::check_iterator(iter, end)) {
+                    return {};
+                }
             }
 
             while((*iter++ >> 7) == 1_b) {
-                if (!Mode::check_iterator(iter, end)) {
-                    return {};
+                if constexpr (Mode::need_checks) {
+                    if (!Mode::check_iterator(iter, end)) {
+                        return {};
+                    }
                 }
             }
 

--- a/include/protopuf/varint.h
+++ b/include/protopuf/varint.h
@@ -49,8 +49,10 @@ namespace pp {
             const auto end = s.end();
 
             do {
-                if (!Mode::check_iterator(iter, end)) {
-                    return {};
+                if constexpr (Mode::need_checks) {
+                    if (!Mode::check_iterator(iter, end)) {
+                        return {};
+                    }
                 }
 
                 *iter = 0b1000'0000_b | std::byte(n);
@@ -69,8 +71,10 @@ namespace pp {
             auto iter = s.begin();
             const auto end = s.end();
 
-            if (!Mode::check_iterator(iter, end)) {
-                return {};
+            if constexpr (Mode::need_checks) {
+                if (!Mode::check_iterator(iter, end)) {
+                    return {};
+                }
             }
 
             std::size_t i = 0;
@@ -78,8 +82,10 @@ namespace pp {
                 n |= static_cast<T>(static_cast<T>(*iter & 0b0111'1111_b) << 7*i);
                 ++iter, ++i;
 
-                if (!Mode::check_iterator(iter, end)) {
-                    return {};
+                if constexpr (Mode::need_checks) {
+                    if (!Mode::check_iterator(iter, end)) {
+                        return {};
+                    }
                 }
             }
             n |= static_cast<T>(static_cast<T>(*iter++) << 7 * i);


### PR DESCRIPTION
Hi,

I've noted terrible performance in debug mode. So, I started to dig what's the problem... and I found algorithmic no issues in your code. So, the performance degradation is probably related to templated code.

Any way, I did minor changed, which led to some performance boost.

Here is a benchmarks (in Release mode):

before:
```
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
BM_protopuf_encode            17.2 ns         17.2 ns     40928792
BM_protopuf_safe_encode       29.7 ns         29.7 ns     22518719
BM_protobuf_encode            68.0 ns         68.0 ns     10340438
BM_protopuf_decode             188 ns          188 ns      3728154
BM_protopuf_safe_decode        217 ns          217 ns      3232510
BM_protobuf_decode             244 ns          244 ns      2906093
```

After:
```
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
BM_protopuf_encode            17.3 ns         17.3 ns     40937909
BM_protopuf_safe_encode       30.5 ns         30.5 ns     22250119
BM_protobuf_encode            69.3 ns         69.3 ns     10183935
BM_protopuf_decode             145 ns          145 ns      4840484
BM_protopuf_safe_decode        162 ns          162 ns      4311272
BM_protobuf_decode             243 ns          243 ns      2895603
```
